### PR TITLE
Remove upper bounds for most packages and cap pytz version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,24 +7,24 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = "^3.9"
 numpy = ">=1.23.0"
-pytz = ">=2020.1"
+pytz = ">=2020.1,<2024.2"
 requests = ">=2.28.2"
 pftools = ">=1.3.10"
-hf-hydrodata = ">=1.1.9"
-pylint = "^3.1.0"
+hf-hydrodata = ">=1.2.5"
+pylint = ">=3.1.0"
 
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.4.0"
-pytest-cov = "^4.1.0"
-jupyter = "^1.0.0"
-matplotlib = "^3.7.2"
-black = "^23.9.1"
-sphinx-autoapi = "^3.0.0"
-sphinx-rtd-theme = "^1.3.0"
+pytest = ">=7.4.0"
+pytest-cov = ">=4.1.0"
+jupyter = ">=1.0.0"
+matplotlib = ">=3.7.2"
+black = ">=23.9.1"
+sphinx-autoapi = ">=3.0.0"
+sphinx-rtd-theme = ">=1.3.0"
 sphinx = "6.2.1"
 myst-nb = {git = "https://github.com/executablebooks/MyST-NB.git"}
 


### PR DESCRIPTION
The pytz version 2024.2 is broken (utc-to-est conversion is wrong). We need to find a more reliable tool for handling timezones.