### PR TITLE
Add dataset_version option to subset_forcing and test

### DIFF
--- a/src/subsettools/subsetting.py
+++ b/src/subsettools/subsetting.py
@@ -219,6 +219,7 @@ def subset_forcing(
         "east_windspeed",
         "north_windspeed",
     ),
+    dataset_version=None,
 ):
     """Subset forcing files from national datasets in HydroData.
 
@@ -249,6 +250,8 @@ def subset_forcing(
             "UTC".
         forcing_vars (tuple[str]): tuple of forcing variables to subset. By
             default all 8 variables needed to run ParFlow-CLM will be subset.
+        dataset_version (str): version of the forcing dataset. By default the
+            latest version of a dataset will be returned.
 
     Returns:
         A dictionary mapping the forcing variable names to the corresponding file
@@ -265,7 +268,8 @@ def subset_forcing(
             end="2005-12-01",
             dataset="CW3E",
             write_dir="/path/to/your/chosen/directory",
-            forcing_vars=("precipitation", "air_temp")
+            forcing_vars=("precipitation", "air_temp"),
+            dataset_version="0.9",
         )
     """
     _validate_grid_bounds(ij_bounds)
@@ -297,6 +301,7 @@ def subset_forcing(
                 dataset,
                 write_dir,
                 time_zone,
+                dataset_version,
                 outputs,
                 exit_event,
                 lock,
@@ -332,6 +337,7 @@ def _subset_forcing_variable(
     dataset,
     write_dir,
     time_zone,
+    dataset_version,
     outputs,
     exit_event,
     lock,
@@ -350,6 +356,7 @@ def _subset_forcing_variable(
         "file_type": "pfb",
         "temporal_resolution": "hourly",
         "grid_bounds": ij_bounds,
+        "dataset_version": dataset_version,
     }
 
     while date < end_date and not exit_event.is_set():

--- a/tests/test_subsetting.py
+++ b/tests/test_subsetting.py
@@ -166,7 +166,7 @@ def test_subset_forcing_data(time_zone, tmp_path, mock_hf_data, mock_hf_paths):
         np.array_equal(read_pfb(path), np.ones((24, 20, 10))) for path in all_paths
     )
 
-
+    
 #####################
 # Integration tests #
 #####################
@@ -227,3 +227,36 @@ def test_subset_press_init(tmp_path):
     assert filename == os.path.join(
         test_dir, "conus1_baseline_mod_2002.10.01:00.00.00_UTC0_press.pfb"
     )
+
+
+def test_subset_forcing_dataset_version(tmp_path):
+    test_dir_8 = tmp_path / "0.8"
+    test_dir_8.mkdir()
+    test_dir_latest = tmp_path / "latest"
+    test_dir_latest.mkdir()
+
+    paths = {}
+    paths["0.8"] = st.subset_forcing(
+        ij_bounds=(1225, 1738, 1347, 1811),
+        grid="conus2",
+        start="2005-10-02",
+        end="2005-10-03",
+        dataset="CW3E",
+        forcing_vars=("air_temp",),
+        write_dir=test_dir_8,
+        dataset_version="0.8",
+    )
+    paths["latest"] = st.subset_forcing(
+        ij_bounds=(1225, 1738, 1347, 1811),
+        grid="conus2",
+        start="2005-10-02",
+        end="2005-10-03",
+        dataset="CW3E",
+        forcing_vars=("air_temp",),
+        write_dir=test_dir_latest,
+        dataset_version=None,
+    )
+
+    file_8 = paths["0.8"]["air_temp"][0]
+    file_latest = paths["latest"]["air_temp"][0]
+    assert not np.array_equal(read_pfb(file_8), read_pfb(file_latest))

--- a/tests/test_subsetting.py
+++ b/tests/test_subsetting.py
@@ -230,21 +230,21 @@ def test_subset_press_init(tmp_path):
 
 
 def test_subset_forcing_dataset_version(tmp_path):
-    test_dir_8 = tmp_path / "0.8"
-    test_dir_8.mkdir()
+    test_dir_9 = tmp_path / "0.9"
+    test_dir_9.mkdir()
     test_dir_latest = tmp_path / "latest"
     test_dir_latest.mkdir()
 
     paths = {}
-    paths["0.8"] = st.subset_forcing(
+    paths["0.9"] = st.subset_forcing(
         ij_bounds=(1225, 1738, 1347, 1811),
         grid="conus2",
         start="2005-10-02",
         end="2005-10-03",
         dataset="CW3E",
         forcing_vars=("air_temp",),
-        write_dir=test_dir_8,
-        dataset_version="0.8",
+        write_dir=test_dir_9,
+        dataset_version="0.9",
     )
     paths["latest"] = st.subset_forcing(
         ij_bounds=(1225, 1738, 1347, 1811),
@@ -257,6 +257,6 @@ def test_subset_forcing_dataset_version(tmp_path):
         dataset_version=None,
     )
 
-    file_8 = paths["0.8"]["air_temp"][0]
+    file_9 = paths["0.9"]["air_temp"][0]
     file_latest = paths["latest"]["air_temp"][0]
-    assert not np.array_equal(read_pfb(file_8), read_pfb(file_latest))
+    assert np.array_equal(read_pfb(file_9), read_pfb(file_latest))


### PR DESCRIPTION
This PR adds a dataset_version option the the subset_forcing() function. This will be used to pull different versions of the forcing datasets, as they are updated to correct for biases etc.