### PR TITLE
Fix dataset version test

### DIFF
--- a/tests/test_subsetting.py
+++ b/tests/test_subsetting.py
@@ -258,21 +258,21 @@ def test_subset_press_init(tmp_path):
 
 
 def test_subset_forcing_dataset_version(tmp_path):
-    test_dir_9 = tmp_path / "0.9"
-    test_dir_9.mkdir()
+    test_dir_1 = tmp_path / "1.0"
+    test_dir_1.mkdir()
     test_dir_latest = tmp_path / "latest"
     test_dir_latest.mkdir()
 
     paths = {}
-    paths["0.9"] = st.subset_forcing(
+    paths["1.0"] = st.subset_forcing(
         ij_bounds=(1225, 1738, 1347, 1811),
         grid="conus2",
         start="2005-10-02",
         end="2005-10-03",
         dataset="CW3E",
         forcing_vars=("air_temp",),
-        write_dir=test_dir_9,
-        dataset_version="0.9",
+        write_dir=test_dir_1,
+        dataset_version="1.0",
     )
     paths["latest"] = st.subset_forcing(
         ij_bounds=(1225, 1738, 1347, 1811),
@@ -285,6 +285,6 @@ def test_subset_forcing_dataset_version(tmp_path):
         dataset_version=None,
     )
 
-    file_9 = paths["0.9"]["air_temp"][0]
+    file_1 = paths["1.0"]["air_temp"][0]
     file_latest = paths["latest"]["air_temp"][0]
-    assert np.array_equal(read_pfb(file_9), read_pfb(file_latest))
+    assert np.array_equal(read_pfb(file_1), read_pfb(file_latest))


### PR DESCRIPTION
The latest version of the forcing datasets is "1.0", updated from "0.9".