### PR TITLE
fix subset_forcing to work with subgrid size 1x1 with new algorithm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "subsettools"
-version = "2.0.4"
+version = "2.0.5"
 description = "Subsetting tools and utilities for ParFlow"
 authors = ["George Artavanis, Amanda Triplett"]
 license = "MIT"

--- a/src/subsettools/_common.py
+++ b/src/subsettools/_common.py
@@ -5,12 +5,13 @@ from zoneinfo import ZoneInfo
 import importlib
 import hf_hydrodata as hf
 
+SUBSETTOOLS_VERSION = importlib.metadata.version("subsettools")
 
 def get_hf_gridded_data(options):
     "Wrapper around hf_hydrodata.get_gridded_data to handle various exceptions."
 
     try:
-        _add_subsettool_version(options)
+        options["subsettools"] = SUBSETTOOLS_VERSION
         data = hf.get_gridded_data(options)
     except ValueError as err:
         raise ValueError(
@@ -41,12 +42,3 @@ def get_utc_time(date_string, time_zone):
             .replace(tzinfo=None)
         )
     return date
-
-SUBSETTOOLS_VERSION = None
-def _add_subsettool_version(options):
-    """Add subsettools version to options"""
-    
-    global SUBSETTOOLS_VERSION
-    if SUBSETTOOLS_VERSION is None:
-        SUBSETTOOLS_VERSION = importlib.metadata.version("subsettools")
-    options["subsettools"] = SUBSETTOOLS_VERSION

--- a/src/subsettools/_common.py
+++ b/src/subsettools/_common.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from zoneinfo import ZoneInfo
+import importlib
 import hf_hydrodata as hf
 
 
@@ -9,6 +10,7 @@ def get_hf_gridded_data(options):
     "Wrapper around hf_hydrodata.get_gridded_data to handle various exceptions."
 
     try:
+        _add_subsettool_version(options)
         data = hf.get_gridded_data(options)
     except ValueError as err:
         raise ValueError(
@@ -39,3 +41,12 @@ def get_utc_time(date_string, time_zone):
             .replace(tzinfo=None)
         )
     return date
+
+SUBSETTOOLS_VERSION = None
+def _add_subsettool_version(options):
+    """Add subsettools version to options"""
+    
+    global SUBSETTOOLS_VERSION
+    if SUBSETTOOLS_VERSION is None:
+        SUBSETTOOLS_VERSION = importlib.metadata.version("subsettools")
+    options["subsettools"] = SUBSETTOOLS_VERSION

--- a/src/subsettools/subsetting.py
+++ b/src/subsettools/subsetting.py
@@ -7,7 +7,7 @@ ParFlow simulation.
     - subset initial pressure data
     - subset gridded CLM inputs (vegm)
 """
-#pylint: disable=C0301,R0913,R0914
+#pylint: disable=C0301,R0913,R0914,R0917
 import os
 from datetime import datetime, timedelta
 import threading
@@ -573,6 +573,10 @@ def _get_read_block_size(ij_bounds):
     block_days_per_read = int(
         max_chunking_memory_bytes / (subgrid_byte_size * _HOURS_PER_FORCING_FILE)
     )
+    # Limit number of days per read to 1 year
+    block_days_per_read = min(block_days_per_read, 366)
+
+    # Get number of hours to read per block
     block_hours_per_read = block_days_per_read * _HOURS_PER_FORCING_FILE
 
     if block_days_per_read == 0:

--- a/tests/test_subsetting.py
+++ b/tests/test_subsetting.py
@@ -1,11 +1,16 @@
+""""
+    Unit tests for subset_forcing function.
+"""
+
+# pylint: disable=R0917,C0301,W0621,W0613
+
 import os
-from parflow.tools.io import read_pfb, read_pfb_sequence
+import glob
 import numpy as np
+from parflow.tools.io import read_pfb, read_pfb_sequence
 import subsettools as st
 import hf_hydrodata
 import pytest
-import glob
-import time
 
 _SECONDS_PER_HOUR = 3600
 _DUMMY_NZ = 5
@@ -13,6 +18,8 @@ _DUMMY_NZ = 5
 
 @pytest.fixture
 def mock_hf_data(monkeypatch):
+    """Unit test fixture to use monkeypatch mock calls to get_gridded_data"""
+
     def mock_get_data(options):
         grid_bounds = options.get("grid_bounds")
         resolution = options.get("temporal_resolution")
@@ -32,6 +39,8 @@ def mock_hf_data(monkeypatch):
                 shape = (nt, nj, ni)
         elif resolution == "static":
             shape = (_DUMMY_NZ, nj, ni)
+        else:
+            shape = (1, nj, ni)
         return np.ones(shape)
 
     monkeypatch.setattr(hf_hydrodata, "get_gridded_data", mock_get_data)
@@ -39,6 +48,8 @@ def mock_hf_data(monkeypatch):
 
 @pytest.fixture
 def mock_hf_paths(monkeypatch):
+    """Unit test fixture to mock hf_hydrodata.get(paths)"""
+
     def mock_get_paths(options):
         dataset = options.get("dataset")
         variable = options.get("variable")
@@ -49,6 +60,8 @@ def mock_hf_paths(monkeypatch):
 
 
 def test_subset_static_filenames(tmp_path, mock_hf_data):
+    """Test subset_static with 3 variable names."""
+
     test_dir = tmp_path / "test_static"
     test_dir.mkdir()
     var_list = ("var1", "var2", "var3")
@@ -66,6 +79,8 @@ def test_subset_static_filenames(tmp_path, mock_hf_data):
 
 
 def test_subset_static_data(tmp_path, mock_hf_data):
+    """Test subset_static with precipition."""
+
     test_dir = tmp_path / "test_static"
     test_dir.mkdir()
     static_paths = st.subset_static(
@@ -79,6 +94,8 @@ def test_subset_static_data(tmp_path, mock_hf_data):
 
 
 def test_subset_press_init_filenames(tmp_path, mock_hf_data):
+    """Test subset_press_init"""
+
     test_dir = tmp_path / "test_press_filenames"
     test_dir.mkdir()
     file_path = st.subset_press_init(
@@ -91,6 +108,8 @@ def test_subset_press_init_filenames(tmp_path, mock_hf_data):
 
 
 def test_subset_press_init_data(tmp_path, mock_hf_data):
+    """Test subset_press_init and verify numpy array."""
+
     test_dir = tmp_path / "test_press_data"
     test_dir.mkdir()
     file_path = st.subset_press_init(
@@ -114,9 +133,10 @@ def test_subset_press_init_data(tmp_path, mock_hf_data):
 def test_subset_forcing_num_files(
     end_date, num_files, tmp_path, mock_hf_data, mock_hf_paths
 ):
+    """Test subset_forcing with one forcing variable"""
     test_dir = tmp_path / "test_forcing"
     test_dir.mkdir()
-    paths = st.subset_forcing(
+    st.subset_forcing(
         ij_bounds=(0, 0, 10, 20),
         grid="conus1",
         start="2005-10-01",
@@ -129,6 +149,8 @@ def test_subset_forcing_num_files(
 
 
 def test_subset_forcing_filenames(tmp_path, mock_hf_data, mock_hf_paths):
+    """Test subset_forcing and verify returned file names."""
+
     test_dir = tmp_path / "test_forcing"
     test_dir.mkdir()
     paths = st.subset_forcing(
@@ -147,8 +169,12 @@ def test_subset_forcing_filenames(tmp_path, mock_hf_data, mock_hf_paths):
     assert [os.path.basename(path) for path in paths["var1"]] == expected_files
 
 
-@pytest.mark.parametrize("time_zone", ["UTC", "EST", "US/Pacific", "US/Central", "US/Mountain", "US/Eastern"])
+@pytest.mark.parametrize(
+    "time_zone", ["UTC", "EST", "US/Pacific", "US/Central", "US/Mountain", "US/Eastern"]
+)
 def test_subset_forcing_timezones(time_zone, tmp_path, mock_hf_data, mock_hf_paths):
+    """Test subset forcing with various different timezones."""
+
     test_dir = tmp_path / "test_forcing"
     test_dir.mkdir()
     paths = st.subset_forcing(
@@ -164,23 +190,25 @@ def test_subset_forcing_timezones(time_zone, tmp_path, mock_hf_data, mock_hf_pat
     path = paths["var1"][0]
     assert read_pfb(path).shape == (24, 20, 10)
 
-    
+
 #####################
 # Integration tests #
 #####################
 
 
-@pytest.mark.parametrize("time_zone, utc_offset",
-                         [
-                             ("EST", 5),
-                             ("US/Eastern", 5),
-                             ("US/Central", 6),
-                             ("US/Mountain", 7),                             
-                             ("US/Pacific", 8),
-                         ]
+@pytest.mark.parametrize(
+    "time_zone, utc_offset",
+    [
+        ("EST", 5),
+        ("US/Eastern", 5),
+        ("US/Central", 6),
+        ("US/Mountain", 7),
+        ("US/Pacific", 8),
+    ],
 )
 def test_forcing_timezones(tmp_path, time_zone, utc_offset):
-    "Check if we get the correct data offset for all US timezones."
+    """Check if we get the correct data offset for all US timezones."""
+
     utc = tmp_path / "UTC_out"
     utc.mkdir()
     tz = tmp_path / "tz_out"
@@ -208,19 +236,20 @@ def test_forcing_timezones(tmp_path, time_zone, utc_offset):
         dataset=dataset,
         write_dir=tz,
         time_zone=time_zone,
-        forcing_vars=("air_temp",),        
+        forcing_vars=("air_temp",),
     )
     utc_temp = read_pfb(paths_utc["air_temp"][0])
     tz_temp = read_pfb(paths_tz["air_temp"][0])
     assert np.array_equal(tz_temp[0], utc_temp[utc_offset])
 
-    
+
 def test_forcing_timezone_time_change(tmp_path):
     """Check for when start and end dates cross the time change (EDT->EST)."""
+
     write_dir = tmp_path
     ij_bounds = (375, 239, 487, 329)
     grid = "conus1"
-    start = "2006-04-02" # Time change on 02-04-2006 at 2:00am.
+    start = "2006-04-02"  # Time change on 02-04-2006 at 2:00am.
     end = "2006-04-03"
     dataset = "NLDAS2"
     paths = st.subset_forcing(
@@ -235,7 +264,7 @@ def test_forcing_timezone_time_change(tmp_path):
     )
     data = read_pfb(paths["air_temp"][0])
     assert data.shape == (24, 90, 112)
-    
+
 
 def test_subset_press_init(tmp_path):
     """Check that the call succeeds when it fetches data for the beginning of WY 2003.
@@ -258,6 +287,8 @@ def test_subset_press_init(tmp_path):
 
 
 def test_subset_forcing_dataset_version(tmp_path):
+    """Test subset_forcing with dataset version."""
+
     test_dir_1 = tmp_path / "1.0"
     test_dir_1.mkdir()
     test_dir_latest = tmp_path / "latest"
@@ -289,6 +320,7 @@ def test_subset_forcing_dataset_version(tmp_path):
     file_latest = paths["latest"]["air_temp"][0]
     assert np.array_equal(read_pfb(file_1), read_pfb(file_latest))
 
+
 def test_forcing_conus2_est(tmp_path):
     """Test read_subset_forcing using conus2 for multiple days with a EST timezone."""
 
@@ -309,12 +341,13 @@ def test_forcing_conus2_est(tmp_path):
         dataset=dataset,
         write_dir=tz,
         time_zone=time_zone,
-        forcing_vars=("air_temp",)
+        forcing_vars=("air_temp",),
     )
     result_np = read_pfb_sequence(paths_tz.get("air_temp"))
     assert len(paths_tz.get("air_temp")) == 3
     assert result_np.shape == (3, 24, 90, 112)
     assert np.nansum(result_np) == pytest.approx(206304706.1352234)
+
 
 def test_forcing_conus2_utc(tmp_path):
     """Test read_subset_forcing using conus2 for multiple days with a UTC timezone."""
@@ -334,12 +367,13 @@ def test_forcing_conus2_utc(tmp_path):
         end=end,
         dataset=dataset,
         write_dir=tz,
-        forcing_vars=("air_temp",)
+        forcing_vars=("air_temp",),
     )
     result_np = read_pfb_sequence(paths_tz.get("air_temp"))
     assert len(paths_tz.get("air_temp")) == 3
     assert result_np.shape == (3, 24, 90, 112)
     assert np.nansum(result_np) == pytest.approx(206204619.5949707)
+
 
 def test_forcing_all_variables_timezone(tmp_path):
     """Test read_subset_forcing using conus2 for all variables with a timezone."""
@@ -360,7 +394,8 @@ def test_forcing_all_variables_timezone(tmp_path):
         end=end,
         dataset=dataset,
         write_dir=tz,
-        time_zone=time_zone)
+        time_zone=time_zone,
+    )
 
     assert len(paths_tz) == 8
     result_np = read_pfb_sequence(paths_tz.get("air_temp"))
@@ -369,17 +404,18 @@ def test_forcing_all_variables_timezone(tmp_path):
     assert result_np.shape == (3, 24, 90, 112)
     assert np.nansum(result_np) == pytest.approx(206304706.1352234)
 
+
 def test_forcing_full_conus2(tmp_path):
     """
-        Test ability to subset tools to download a forcing file file
-        with a full conus2 grid.
-        This test can only be executed on a machine with access to /hydrodata files
-        to be able to compare the result with the raw data files. This would not
-        work remotely for older version of subset tools because files were too big.
-     """
+    Test ability to subset tools to download a forcing file file
+    with a full conus2 grid.
+    This test can only be executed on a machine with access to /hydrodata files
+    to be able to compare the result with the raw data files. This would not
+    work remotely for older version of subset tools because files were too big.
+    """
 
     raw_file = "/hydrodata/forcing/processed_data/CONUS2/CW3E_v1.0/hourly/WY2009/CW3E.Temp.003625_to_003648.pfb"
-    if os.path.exists(raw_file):    
+    if os.path.exists(raw_file):
 
         tz = tmp_path / "tz_out"
         tz.mkdir()
@@ -396,10 +432,38 @@ def test_forcing_full_conus2(tmp_path):
             end=end,
             dataset=dataset,
             write_dir=tz,
-            forcing_vars=("air_temp",)
+            forcing_vars=("air_temp",),
         )
         result_np = read_pfb_sequence(paths_tz.get("air_temp"))
         raw_np = read_pfb_sequence([raw_file])
         assert len(paths_tz.get("air_temp")) == 1
         assert result_np.shape == (1, 24, 3256, 4442)
         assert np.array_equal(result_np, raw_np)
+
+
+def test_forcing_1pt(tmp_path):
+    """
+    Test ability to subset tools to download a forcing file file
+    with a 1x1 subgrid size. This caused a bug before.
+    """
+
+    tz = tmp_path / "tz_out"
+    tz.mkdir()
+    start = "2009-10-01"
+    end = "2009-10-06"
+    ij_bounds = (1000, 1000, 1001, 1001)
+    grid = "conus2"
+    dataset = "CW3E"
+
+    paths_tz = st.subset_forcing(
+        ij_bounds=ij_bounds,
+        grid=grid,
+        start=start,
+        end=end,
+        dataset=dataset,
+        write_dir=tz,
+        forcing_vars=("air_temp",),
+    )
+    result_np = read_pfb_sequence([paths_tz.get("air_temp")[0]])
+    assert len(paths_tz.get("air_temp")) == 5
+    assert result_np.shape == (1, 24, 1, 1)

--- a/tests/test_subsetting.py
+++ b/tests/test_subsetting.py
@@ -1,5 +1,5 @@
 """"
-    Unit tests for subset_forcing function.
+    Unit tests for subset tool static functions and subset_forcing function.
 """
 
 # pylint: disable=R0917,C0301,W0621,W0613


### PR DESCRIPTION
Fix subset_forcing function to work with a sub grid size 1x1 using the new algorithm.
This failed because when the number of days/hours to load a time became a very large number with a very small sub grid.
Add a maximum number of days to load at a time for the chunking read to hf_hydrodata.

Also passed subsettools version in options dict for hf_hydrodata get_gridded_data() calls.
Also reformatted modified files with black and fixed pylint issues.
